### PR TITLE
don't drop capitalized words

### DIFF
--- a/pospell.py
+++ b/pospell.py
@@ -126,10 +126,8 @@ def clear(po_path, line):
     line = regex.sub(r"\s+", " ", line)
     to_drop = {
         r'<a href="[^"]*?">',
-        # Strip capitalized words and accronyms in sentences
-        r"(?<!\. |^|-)\b(\p{Letter}['’])?\b\p{Uppercase}\p{Letter}[\w.-]*\b",
-        # Strip accronyms in the beginning of sentences
-        r"(?<=\. |^)\b(\p{Letter}['’])?\b\p{Uppercase}{2,}[\w-]*\b",
+        # Strip accronyms
+        r"\b\p{Uppercase}{2,}\b",
         r"---?",  # -- and --- separators to be ignored
         r"-\\ ",  # Ignore "MINUS BACKSLASH SPACE" typically used in
         # formulas, like '-\ *π*' but *π* gets removed too

--- a/tests/test_pospell.py
+++ b/tests/test_pospell.py
@@ -5,33 +5,17 @@ def test_clear():
     # We don't remove legitimally capitalized first words:
     assert clear("test", "Sport is great.") == "Sport is great."
 
-    # Sometimes we can't guess it's a firstname:
-    assert clear("test", "Julien Palard teste.") == "Julien  teste."
-
     # But we do if clearly accronyms
     assert clear("test", "HTTP is great.") == " is great."
 
     # Also skip accronyms in the middle of a sentence
     assert clear("test", "Because HTTP is great.") == "Because  is great."
 
-    # We remove capitalized words in the middle of a sentence
-    # they are typically names
-    assert clear("test", "Great is Unicode.") == "Great is ."
-
-    # We remove capitalized words even prefixed with l' in french.
-    assert clear("test", "Bah si, l'Unicode c'est bien.") == "Bah si,  c'est bien."
-
     # We remove single letters in quotes
     assert clear("test", "La lettre « é » est seule.") == "La lettre  est seule."
 
     # We drop hours because hunspell whines on them
-    assert clear("test", "Rendez-vous à 10h chez Murex") == "Rendez-vous à  chez "
-
-    # When we removed a dashed name, remove it all
-    assert clear("test", "Marc-André Lemburg a fait") != "Marc-  a fait"
-
-    # Even in the middle of a sentence
-    assert clear("test", "Hier, Marc-André Lemburg a fait") == "Hier,   a fait"
+    assert clear("test", "Rendez-vous à 10h chez Murex") == "Rendez-vous à  chez Murex"
 
     # Drop PEP 440 versions
     assert (


### PR DESCRIPTION
In english capitalized words are only used on the beginning of a sentence or for proper nouns. This is not the case for many other languages, e.g. german.

I think the better approach is to use a personal dictionary with proper nouns if required.