### PR TITLE
Add pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: pospell
+    name: pospell
+    entry: pospell
+    language: python
+    files: \.po$


### PR DESCRIPTION
Adding a pre-commit hook in pospell as I did on `powrap` (https://github.com/JulienPalard/powrap/pull/37)

We are using it on the Spanish translation of the Python Documentation, https://github.com/PyCampES/python-docs-es