### PR TITLE
Add missing return in spell_check function

### DIFF
--- a/pospell.py
+++ b/pospell.py
@@ -328,6 +328,7 @@ def spell_check(
             if look_like_a_word(original):
                 print(checked_file_name, current_line_number, original, sep=":")
                 errors += 1
+    return errors
 
 
 def gracefull_handling_of_missing_dicts(language):


### PR DESCRIPTION
I'm getting a 255 exit error code in [this build](https://travis-ci.com/github/python/python-docs-es/builds/189547058#L322) from pospell even without errors found. I suspect that the missing return is causing the error :thinking: 